### PR TITLE
Add correctly spelled --separate option

### DIFF
--- a/src/options.py
+++ b/src/options.py
@@ -45,6 +45,9 @@ class Options():
                             help='image format of downloaded images, available: (png, jpg)', 
                             choices=['jpg', 'png'], default='jpg')
         self.parser.add_argument('--seperate', required=False,
+                            help='[DEPRECATED] download each chapter in seperate folders',
+                            action='store_true', default=False)
+        self.parser.add_argument('--separate', required=False,
                             help='download each chapter in seperate folders',
                             action='store_true', default=False)
         self.parser.add_argument('--readme', '-r', help=('displays readme file content for '

--- a/src/webtoon_downloader.py
+++ b/src/webtoon_downloader.py
@@ -321,7 +321,7 @@ def download_chapter(chapter_download_task_id: int, session: requests.Session, v
     log.info(f'Chapter {chapter_info.chapter_number} download complete with a total of {len(img_urls)} pages [green]✓')
     progress.remove_task(chapter_download_task_id)
     
-def download_webtoon(series_url: str, start_chapter: int, end_chapter: int, dest: str, images_format: str='jpg', download_latest_chapter=False, seperate_chapters=False):
+def download_webtoon(series_url: str, start_chapter: int, end_chapter: int, dest: str, images_format: str='jpg', download_latest_chapter=False, separate_chapters=False):
     """
     downloads all chaptersstarting from start_chapter until end_chapter, inclusive.
     stores the downloaded chapter into the dest path.
@@ -345,8 +345,8 @@ def download_webtoon(series_url: str, start_chapter: int, end_chapter: int, dest
         destination folder path to store the downloaded image files of the chapter.
         (default: current working directory)
 
-    seperate_chapters: bool
-        seperate downloaded chapters in their own folder under the dest path if true, 
+    separate_chapters: bool
+        separate downloaded chapters in their own folder under the dest path if true, 
         else stores all images in the dest folder.
     """
     session = requests.session()
@@ -388,7 +388,7 @@ def download_webtoon(series_url: str, start_chapter: int, end_chapter: int, dest
         with ThreadPoolExecutor(max_workers=4) as pool:
             chapter_download_futures = set()
             for chapter_info in itertools.islice(chapters_to_download, n_concurrent_chapters_download):
-                    chapter_dest = os.path.join(dest, str(chapter_info.chapter_number)) if seperate_chapters else dest
+                    chapter_dest = os.path.join(dest, str(chapter_info.chapter_number)) if separate_chapters else dest
                     chapter_download_task = progress.add_task(f"[plum2]Chapter {chapter_info.chapter_number}.",  type='Pages', type_color='grey85', number_format='>02d', start=False, rendered_total='??')
                     chapter_download_futures.add(
                         pool.submit(download_chapter, chapter_download_task, session, viewer_url, chapter_info, chapter_dest, images_format)
@@ -407,7 +407,7 @@ def download_webtoon(series_url: str, start_chapter: int, end_chapter: int, dest
 
                 # Scheduling the next set of futures.
                 for chapter_info in itertools.islice(chapters_to_download, len(done)):
-                    chapter_dest = os.path.join(dest, str(chapter_info.chapter_number)) if seperate_chapters else dest
+                    chapter_dest = os.path.join(dest, str(chapter_info.chapter_number)) if separate_chapters else dest
                     chapter_download_task = progress.add_task(f"[plum2]Chapter {chapter_info.chapter_number}.", type='Pages', type_color='grey85', number_format='>02d', start=False, rendered_total='??')
                     chapter_download_futures.add(
                         pool.submit(download_chapter, chapter_download_task, session, viewer_url, chapter_info, chapter_dest, images_format)
@@ -431,7 +431,8 @@ def main():
             console.print(markdown)
             return
     series_url = args.url
-    download_webtoon(series_url, args.start, args.end, args.dest, args.images_format, args.latest, args.seperate)
+    separate = args.seperate or args.separate
+    download_webtoon(series_url, args.start, args.end, args.dest, args.images_format, args.latest, separate)
 
 if(__name__ == '__main__'):
     main()


### PR DESCRIPTION
I'm leaving the incorrect spelling in place for backwards compatibility, marked as deprecated in the help string.