### PR TITLE
Add compress to cbz option

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,12 @@ For example, downloading Tower of God, Chapter 150 would result in the following
             │...
     ```
 
+* When downloading images into separate directories, the individual directories can additionally be compressed into .cbz files by providing the ```--cbz``` argument.
+    ```ps
+    $ python webtoon_downloader.py [url] --separate --cbz
+    ```
+    > NOTE: The ```--cbz``` argument only works when the ```--separate``` argument is also provided.
+
 For more details on positional arguments, please use the ```-h ``` or ```--help``` argument:
 ```console
 py webtoon_downloader.py --help

--- a/README.md
+++ b/README.md
@@ -109,9 +109,9 @@ For example, downloading Tower of God, Chapter 150 would result in the following
     $ python webtoon_downloader.py [url] --dest ./path/to/parent/folder/of/downloaded/images
     ```
 
-* The downloaded images of the chapters are by default all located in the ```[dest]```, however these images can be seperated into seperate directories by providing the ```--seperate``` argument, where each directory corresponds to a downloaded chapter.
+* The downloaded images of the chapters are by default all located in the ```[dest]```, however these images can be separated into separate directories by providing the ```--separate``` argument, where each directory corresponds to a downloaded chapter.
     ```ps
-    $ python webtoon_downloader.py [url] --seperate
+    $ python webtoon_downloader.py [url] --separate
     ```
   For example, downloading Tower of God, Chapter 150 to 152 would result in the following:
     ```ps  

--- a/src/options.py
+++ b/src/options.py
@@ -16,6 +16,16 @@ class MutuallyExclusiveArgumentsError(Exception):
         super().__init__(self.message)
     pass
 
+class DependentArgumentsError(Exception):
+    '''Exception raised when an argument is dependent on another arguments'''
+    
+    def __init__(self, arg1, arg2):
+        self.arg1 = arg1
+        self.arg2 = arg2
+        self.message = f"Argument {arg1} is dependent on {arg2}"
+        super().__init__(self.message)
+    pass
+
 class Options():
     def __init__(self, description='Webtoon Downloader', console = Console()):
         self.parser = ArgumentParser()
@@ -78,6 +88,9 @@ class Options():
         elif (self.args.start and self.args.latest) or (self.args.end and self.args.latest):
             self.parser.print_help()
             raise MutuallyExclusiveArgumentsError(['-s','--start', '-e', '--end'], ['-l', '--latest'])
+        elif (self.args.cbz and not self.args.separate):
+            self.parser.print_help()
+            raise DependentArgumentsError('--cbz', '--separate')
         return self.args
 
 class ArgumentParser(argparse.ArgumentParser):

--- a/src/options.py
+++ b/src/options.py
@@ -52,6 +52,9 @@ class Options():
                             action='store_true', default=False)
         self.parser.add_argument('--readme', '-r', help=('displays readme file content for '
                             'more help details'), required=False, action='store_true')
+        self.parser.add_argument('--cbz', required=False,
+                            help='compress each chapter to a .cbz comic archive. Only works when also using the --separate option',
+                            action='store_true', default=False)
         self.parser._positionals.title = "commands"
 
     def print_readme(self):

--- a/src/webtoon_downloader.py
+++ b/src/webtoon_downloader.py
@@ -454,7 +454,7 @@ def main():
             return
     series_url = args.url
     separate = args.seperate or args.separate
-    compress_cbz = args.cbz and args.separate
+    compress_cbz = args.cbz and separate
     download_webtoon(series_url, args.start, args.end, args.dest, args.images_format, args.latest, separate, compress_cbz)
 
 if(__name__ == '__main__'):


### PR DESCRIPTION
- Enhanced the `--separate` option with a `--cbz` option, which compresses each chapter into a .cbz file
- Updated the usage information with the new option
- Fix the spelling of 'separate' in the usage information