### PR TITLE
feat: add option for naming folders with chapter name

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,30 @@ For example, downloading Tower of God, Chapter 150 would result in the following
             │...
     ```
 
+* In order to use chapter names instead of chapter numbers for separate folders, pass the ```--chapter-name``` argument along with ```--separate```.
+    ```ps
+    $ python webtoon_downloader.py [url] --separate --chapter-name
+    ```
+For example, downloading Tower of God, Chapter 150 to 152 with this option would result in the following:
+    ```ps
+    Tower_of_God
+        │[Season 2] Ep. 70
+            │--150_001.jpg
+            │--150_002.jpg
+            │--150_003.jpg
+            │...
+        │[Season 2] Ep. 71
+            │--151_001.jpg
+            │--151_002.jpg
+            │--151_003.jpg
+            │...
+        │[Season 2] Ep. 72
+            │--152_001.jpg
+            │--152_002.jpg
+            │--152_003.jpg
+            │...
+    ```
+
 For more details on positional arguments, please use the ```-h ``` or ```--help``` argument:
 ```console
 py webtoon_downloader.py --help

--- a/src/options.py
+++ b/src/options.py
@@ -50,6 +50,9 @@ class Options():
         self.parser.add_argument('--separate', required=False,
                             help='download each chapter in seperate folders',
                             action='store_true', default=False)
+        self.parser.add_argument('--chapter-name', required=False,
+                            help='use the chapter title for the separate folder names',
+                            action='store_true', default=False)
         self.parser.add_argument('--readme', '-r', help=('displays readme file content for '
                             'more help details'), required=False, action='store_true')
         self.parser._positionals.title = "commands"


### PR DESCRIPTION
Addresses https://github.com/Zehina/Webtoon-Downloader/issues/3. 

I've added an argument `--chapter-name`, that when used in conjunction with `--separate`, will use the title of the `ChapterInfo` instead of the chapter number for the folder name.

Note: image names remain unaffected by this change.

Hope this helps, and I'm happy to make any revisions necessary.