### PR TITLE
gitignore: add output of "pip install" run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 __pycache__/
+Webtoon_Downloader/
+Webtoon_Downloader.egg-info/
+Webtoon_Downloader-*.egg


### PR DESCRIPTION
Add the `Webtoon_Downloader.egg-info` directory (below `src`), the `Webtoon_Downloader-*.egg` distributable generated by a `pip install .` run. Also add the `Webtoon_Downloader` directory that should have been generated below `build/lib` but currently isn't.