### PR TITLE
Add --export-texts option

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,9 @@ For example, downloading Tower of God, Chapter 150 would result in the following
     ```
 
 * You can additionally export the summary, chapter-title and author-notes into text files.
+You can select the format for the output as either JSON (default) or plain text files or both.
     ```ps
-    $ webtoon-downloader [url] --export-texts
+    $ webtoon-downloader [url] --export-texts [--export-format <json|text|all>]
     ```
 
 For more details on positional arguments, please use the ```-h ``` or ```--help``` argument:

--- a/README.md
+++ b/README.md
@@ -133,6 +133,11 @@ For example, downloading Tower of God, Chapter 150 would result in the following
             │...
     ```
 
+* You can additionally export the summary, chapter-title and author-notes into text files.
+    ```ps
+    $ webtoon-downloader [url] --export-texts
+    ```
+
 For more details on positional arguments, please use the ```-h ``` or ```--help``` argument:
 ```console
 py webtoon_downloader.py --help

--- a/src/options.py
+++ b/src/options.py
@@ -50,6 +50,10 @@ class Options():
         self.parser.add_argument('--separate', required=False,
                             help='download each chapter in seperate folders',
                             action='store_true', default=False)
+        self.parser.add_argument('--export-texts', required=False,
+                            help=('export series summary, chapter name and author '
+                                  'texts into additional text files'),
+                            action='store_true', default=False)
         self.parser.add_argument('--readme', '-r', help=('displays readme file content for '
                             'more help details'), required=False, action='store_true')
         self.parser._positionals.title = "commands"

--- a/src/options.py
+++ b/src/options.py
@@ -51,9 +51,12 @@ class Options():
                             help='download each chapter in seperate folders',
                             action='store_true', default=False)
         self.parser.add_argument('--export-texts', required=False,
-                            help=('export series summary, chapter name and author '
-                                  'texts into additional text files'),
+                            help=('export texts like series summary, chapter name or author '
+                                  'notes into additional files'),
                             action='store_true', default=False)
+        self.parser.add_argument('--export-format', required=False,
+                            help='format to store exported texts in, available: (all, json, text)',
+                            choices=['all', 'json', 'text'], default='json')
         self.parser.add_argument('--readme', '-r', help=('displays readme file content for '
                             'more help details'), required=False, action='store_true')
         self.parser._positionals.title = "commands"


### PR DESCRIPTION
Add a new option --export-texts that extracts several texts from the various webpages and stores them as text-files:

 * `summary.txt` contains the series summary from the series list page
 * `*_title.txt` contains the title of each chapter
 * `*_notes.txt` contains the author notes of each chapter, if present

<del>If --export-texts is used together with --separate, then this changes the names of the chapter-directores: they now have a suffix based on the title.</del>

Add --export-format option
    
Add an option that modifies how --export-texts behaves: either write the texts to individual plain text files or to a single JSON file or write both.
