### PR TITLE
Cleanup/installed script

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ For example, downloading Tower of God, Chapter 150 would result in the following
 
 * The downloaded images of the chapters are by default all located in the ```[dest]```, however these images can be separated into separate directories by providing the ```--separate``` argument, where each directory corresponds to a downloaded chapter.
     ```ps
-    $ webtoon_downloader.py [url] --separate
+    $ webtoon-downloader [url] --separate
     ```
   For example, downloading Tower of God, Chapter 150 to 152 would result in the following:
     ```ps  


### PR DESCRIPTION
One of the command lines in the README files contains the name of the python script instead of the installed script: it won't work for the user like this, so fix that.

This is a left-over from the conflict-resolution between #30 and #33.