### PR TITLE
Fix written image-format

### DIFF
--- a/src/options.py
+++ b/src/options.py
@@ -42,8 +42,9 @@ class Options():
         self.parser.add_argument('-d', '--dest', type=str,
                             help='download parent folder path', required= False)
         self.parser.add_argument('--images-format', required=False,
-                            help='image format of downloaded images, available: (png, jpg)', 
-                            choices=['jpg', 'png'], default='jpg')
+                            help='image format of downloaded images, available: '
+                                 '(native, png, jpg)',
+                            choices=['native', 'jpg', 'png'], default='native')
         self.parser.add_argument('--seperate', required=False,
                             help='[DEPRECATED] download each chapter in separate folders',
                             action='store_true', default=False)


### PR DESCRIPTION
The default behaviour is to name all files as `<basename>.jpg` on the assumption that all images are downloaded with type `image/jpeg`. But this is not necessarily true, images may also be downloaded as `image/png` in which case the file-name is wrong.

To fix this, add a new choice `native` to the option `--images-format` and have it detect the actual downloaded image type from the `Content-Type` header. Make this new choice the (changed) default choice. Keep the choices `jpg` and `png` but enforce conversion in both cases if the downloaded image does not match the desired format.