### PR TITLE
Change 'save-as' short option to '-sa'

### DIFF
--- a/webtoon_downloader/cmd/cli.py
+++ b/webtoon_downloader/cmd/cli.py
@@ -95,7 +95,7 @@ def validate_concurrent_count(ctx: Any, param: Any, value: int | None) -> int | 
 )
 @click.option(
     "--save-as",
-    "-s",
+    "-sa",
     type=click.Choice(["images", "zip", "cbz", "pdf"]),
     default="images",
     show_default=True,


### PR DESCRIPTION
**PR Checklist**

- [X] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [X] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation is updated

**Description of changes**

Both "--start" and "--save-as" had the short option name "-s", which lead to unexpected behaviour (running only as --save-as). This can be solved by changing one of them. I determined the one that fits more for change is the "save-as" option to "-sa".

Just to let you know, I'm new into this, I don't know if there should be a test for this, or documentation anywhere else, or if it even works (which I believe so, as it's the only reference to the arguments names, but I haven't tested it).

Thanks.