### PR TITLE
Set the url scheme if not provided by the user

### DIFF
--- a/webtoon_downloader/core/webtoon/downloaders/chapter.py
+++ b/webtoon_downloader/core/webtoon/downloaders/chapter.py
@@ -79,7 +79,9 @@ class ChapterDownloader:
         await self._report_progress(chapter_info, "Start")
 
         resp = await self.client.get(chapter_info.viewer_url)
-        print('Fetched: "%s" from chapter "%s" => %s', chapter_info.viewer_url, chapter_info.title, resp.status_code)
+        log.debug(
+            'Fetched: "%s" from chapter "%s" => %s', chapter_info.viewer_url, chapter_info.title, resp.status_code
+        )
         extractor = WebtoonViewerPageExtractor(resp.text)
         img_urls = extractor.get_img_urls()
         await self._report_progress(chapter_info, "ChapterInfoFetched", extractor)

--- a/webtoon_downloader/core/webtoon/downloaders/comic.py
+++ b/webtoon_downloader/core/webtoon/downloaders/comic.py
@@ -67,6 +67,11 @@ class WebtoonDownloader:
         self.url = re.sub(r"\\(?=[?=&])", "", self.url)
         url = furl(self.url)
 
+        # if the url has no scheme, attempt to add one
+        if not url.scheme:
+            self.url = f"https://{self.url}"
+            url = furl(self.url)
+
         if not url.scheme or not url.host:
             raise WebtoonDownloadError(self.url, cause=ValueError("Invalid URL"))
 


### PR DESCRIPTION
**PR Checklist**

Resolves #68

- [X] A description of the changes is added to the description of this PR.
- [X] If there is a related issue, make sure it is linked to this PR.

When provided with a url with no scheme (ex: "www.webtoons.com/**/*") we append the expected `https` scheme at the beginning of the url