### PR TITLE
Downloads in full quality

### DIFF
--- a/webtoon_downloader/core/downloaders/image.py
+++ b/webtoon_downloader/core/downloaders/image.py
@@ -61,6 +61,8 @@ class ImageDownloader:
         """
         try:
             async with self._semaphore:
+                # Attempt to remove Webtoons compression by removing "?type=q90" at the end of URLs
+                url = url.replace("?type=q90", "")
                 return await self._download_image(self.client, url, target, storage)
         except Exception as exc:
             raise ImageDownloadError(url=url, cause=exc) from exc

--- a/webtoon_downloader/core/downloaders/image.py
+++ b/webtoon_downloader/core/downloaders/image.py
@@ -61,8 +61,6 @@ class ImageDownloader:
         """
         try:
             async with self._semaphore:
-                # Attempt to remove Webtoons compression by removing "?type=q90" at the end of URLs
-                url = url.replace("?type=q90", "")
                 return await self._download_image(self.client, url, target, storage)
         except Exception as exc:
             raise ImageDownloadError(url=url, cause=exc) from exc

--- a/webtoon_downloader/core/webtoon/extractor.py
+++ b/webtoon_downloader/core/webtoon/extractor.py
@@ -153,4 +153,8 @@ class WebtoonViewerPageExtractor:
             raise ElementNotFoundError("all_img")
 
         self._img_urls = [tag["data-url"] for tag in _tags]
+
+        # Attempt to remove Webtoons compression by removing "?type=q90" at the end of URLs
+        self._img_urls = [url.replace("?type=q90", "") for url in self._img_urls]
+
         return self._img_urls


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation is updated

**Description of changes**
Currently the downloader is downloading at 90% quality as it's the default when pulled from Webtoons website. By removing the quality query at the end of download urls, images can be downloaded at full quality.