### PR TITLE
Update tox envlist to match CI/CD pipeline

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = true
-envlist = py38, py39, py310, py311, py312
+envlist = py310, py311, py312, py313
 
 [gh-actions]
 python =


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] ~~If there is a related issue, make sure it is linked to this PR.~~ N/A
- [ ] ~~If you've fixed a bug or added code that should be tested, add tests!~~ N/A
- [ ] ~~Documentation is updated~~ N/A

**Description of changes**
In `CONTRIBUTING.md`, the instructions for `tox` talks about how the step is triggered in the CI/CD pipeline
https://github.com/Zehina/Webtoon-Downloader/blob/054d1966519ce1b648a1b668613f1d71761f3f9a/CONTRIBUTING.md?plain=1#L98-L106

However, locally tox uses different python versions than the CI/CD does:

**tox python versions**
https://github.com/Zehina/Webtoon-Downloader/blob/054d1966519ce1b648a1b668613f1d71761f3f9a/tox.ini#L3

**CI/CD python versions**
https://github.com/Zehina/Webtoon-Downloader/blob/054d1966519ce1b648a1b668613f1d71761f3f9a/tox.ini#L6-L10

This PR configures the local run of tox to run in parity with the current CI/CD pipeline.