### PR TITLE
Added support for mature series

### DIFF
--- a/webtoon_downloader/core/webtoon/extractor.py
+++ b/webtoon_downloader/core/webtoon/extractor.py
@@ -143,6 +143,10 @@ class WebtoonViewerPageExtractor:
 
         urls: list[str] = []
 
+        # Detect mature-content overlay (visual-only gate)
+        if self._soup.select_one("div.ly_wrap.fixed.on div.ly_adult"):
+            log.debug("Mature content overlay detected; attempting fallback image extraction")
+        
         # 1️⃣ Preferred: normal viewer container (non-mature pages)
         _nav = self._soup.find(
             "div",


### PR DESCRIPTION
Added support for mature series

**PR Checklist**

- [X] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation is updated

**Description of changes**

This PR fixes image extraction failures on **Mature (18+) WEBTOON episodes** that display the “Proceed to view content” overlay.

Previously, the downloader hard-failed when the standard `viewer_img _img_viewer_area` container was missing, even though the episode images were still present in the DOM behind the overlay. This resulted in image extraction errors for mature series.

### What changed
- Added detection for the mature-content overlay (`.ly_adult`)
- Added a **safe fallback** to extract images by scanning for `img[data-url]` when the standard container is not found
- Added a **debug-only log line** indicating when a mature overlay is detected and fallback extraction is used
- Preserved existing behavior for non-mature series

### User impact
- Mature WEBTOON episodes now download successfully without requiring cookies, login, or additional flags
- No behavior changes for non-mature content
- Additional debug visibility when `--debug` is enabled

This change improves robustness against WEBTOON’s viewer layout variations while keeping the scraper’s behavior backward-compatible.