### PR TITLE
Deploy docs with GitHub Pages workflow

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,48 @@
+name: Deploy Pages
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v6
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Set up the environment
+        uses: ./.github/actions/setup-uv-env
+
+      - name: Build documentation
+        run: uv run mkdocs build --strict
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: site
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/on-release-main.yml
+++ b/.github/workflows/on-release-main.yml
@@ -25,16 +25,3 @@ jobs:
         env:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
           RELEASE_VERSION: ${{ steps.vars.outputs.tag }}
-
-  deploy-docs:
-    runs-on: ubuntu-latest
-    needs: publish
-    steps:
-      - name: Check out
-        uses: actions/checkout@v6
-
-      - name: Set up the environment
-        uses: ./.github/actions/setup-uv-env
-
-      - name: Deploy documentation
-        run: uv run mkdocs gh-deploy --force

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: webtoon-downloader
 repo_url: https://github.com/Zehina/webtoon-downloader
-site_url: https://Zehina.github.io/webtoon-downloader
+site_url: https://zehina.github.io/Webtoon-Downloader/
 site_description: CLI downloader for saving Webtoons series as images, ZIPs, CBZs, or PDFs.
 site_author: Ali Taibi
 edit_uri: edit/master/docs/


### PR DESCRIPTION
## Summary
- add a dedicated GitHub Pages workflow that builds MkDocs and deploys on pushes to `master`
- stop using the old release-only `mkdocs gh-deploy` path, which no longer matches the current Pages setup
- update the docs `site_url` to the canonical GitHub Pages URL

## Verification
- uv run mkdocs build --strict