### PR TITLE
Add WebP as a target conversion format

### DIFF
--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -20,6 +20,11 @@ from webtoon_downloader.transformers.image import (
         ("JPEG", "JPEG", "RGB"),
         ("PNG", "JPEG", "P"),
         ("PNG", "PNG", "P"),
+        ("PNG", "WEBP", "RGB"),
+        ("JPEG", "WEBP", "RGB"),
+        ("WEBP", "WEBP", "RGB"),
+        ("WEBP", "PNG", "RGB"),
+        ("WEBP", "JPEG", "RGB"),
     ],
 )
 async def test_image_format_transformer(original_format: str, target_format: ImageFormat, mode: str) -> None:

--- a/webtoon_downloader/cmd/cli.py
+++ b/webtoon_downloader/cmd/cli.py
@@ -101,7 +101,7 @@ def _unwrap_error_chain(exc: Exception) -> list[str]:
 @click.option(
     "--image-format",
     "-f",
-    type=click.Choice(["jpg", "png"]),
+    type=click.Choice(["jpg", "png", "webp"]),
     default="jpg",
     show_default=True,
     help="Image format of downloaded images",

--- a/webtoon_downloader/transformers/image.py
+++ b/webtoon_downloader/transformers/image.py
@@ -12,12 +12,12 @@ from PIL import Image
 
 log = logging.getLogger(__name__)
 
-ImageFormat = Literal["PNG", "JPG", "JPEG"]
+ImageFormat = Literal["PNG", "JPG", "JPEG", "WEBP"]
 """
 Defines the permissible image formats for transformation.
 """
 
-_ValidImageFormats = Literal["PNG", "JPEG"]
+_ValidImageFormats = Literal["PNG", "JPEG", "WEBP"]
 """
 Defines the valid image formats for transformation.
 """
@@ -57,6 +57,8 @@ class AioImageFormatTransformer:
     def __post_init__(self) -> None:
         if self.target_format.upper() in ["JPG", "JPEG"]:
             self._target_format = "JPEG"  # JPG is not a valid format to check. and JPG == JPEG anyways
+        elif self.target_format.upper() == "WEBP":
+            self._target_format = "WEBP"
         else:
             self._target_format = "PNG"
 


### PR DESCRIPTION
## Summary
- Add `WEBP` to `ImageFormat` / `_ValidImageFormats` and handle it in `AioImageFormatTransformer.__post_init__`.
- Expose `webp` as a value of the `--image-format` / `-f` CLI option.
- Reuse the existing PIL save path — WebP supports transparency natively, so no JPEG-style RGB flattening is needed.

## Motivation
WebP yields noticeably smaller files than PNG at comparable visual quality and still supports alpha, making it a useful middle ground for archived webtoon downloads.

## Usage
```bash
webtoon-downloader <url> -f webp
```

## Test plan
- [x] `pytest tests/test_transformers.py` — 11 passed (5 new WebP cases: `PNG→WEBP`, `JPEG→WEBP`, `WEBP→WEBP` no-op, `WEBP→PNG`, `WEBP→JPEG`)
- [x] End-to-end smoke test: `webtoon-downloader <url> -f webp`

## Notes
- No new dependencies — Pillow already ships with WebP encoder/decoder support.
- `_target_format_suffix()` is unchanged; it produces `.webp` automatically from the `target_format` field.