### PR TITLE
fix canvas episode requests

### DIFF
--- a/tests/test_comicinfo.py
+++ b/tests/test_comicinfo.py
@@ -10,10 +10,17 @@ import httpx
 import pytest
 
 from webtoon_downloader.core.downloaders.image import ImageDownloadResult
+from webtoon_downloader.core.webtoon.api import (
+    REQUEST_ALL_EPISODES_PAGE_SIZE,
+)
 from webtoon_downloader.core.webtoon.client import WebtoonHttpClient
 from webtoon_downloader.core.webtoon.comicinfo import ComicInfoMetadata, SeriesMetadata, build_comicinfo_xml
 from webtoon_downloader.core.webtoon.downloaders.chapter import ChapterDownloader
 from webtoon_downloader.core.webtoon.downloaders.comic import WebtoonDownloader
+from webtoon_downloader.core.webtoon.fetchers import (
+    END_CHAPTER_LATEST,
+    WebtoonFetcher,
+)
 from webtoon_downloader.core.webtoon.models import ChapterInfo
 from webtoon_downloader.core.webtoon.namer import NonSeparateFileNameGenerator
 from webtoon_downloader.storage import AioWriter, AioZipWriter
@@ -104,6 +111,105 @@ def test_build_comicinfo_xml_special_chars_and_roundtrip() -> None:
     parsed = ET.fromstring(xml)  # noqa: S314
     assert parsed.findtext("Series") == "Tom & Jerry <Classic>"
     assert parsed.findtext("Summary") == "Que désirez-vous?"
+
+
+@pytest.mark.asyncio
+async def test_canvas_chapters_use_reading_language() -> None:
+    url = "https://www.webtoons.com/en/canvas/frog-wizards-of-chana-tower/list?title_no=883187"
+    mobile_url = "https://m.webtoons.com/en/canvas/frog-wizards-of-chana-tower/list?title_no=883187"
+    api_url = (
+        "https://m.webtoons.com/api/v1/canvas/883187/episodes"
+        f"?pageSize={REQUEST_ALL_EPISODES_PAGE_SIZE}&readingLanguageCode=en"
+    )
+
+    main_html = """
+    <html><head>
+      <link rel='canonical' href='https://www.webtoons.com/en/canvas/frog-wizards-of-chana-tower/list?title_no=883187' />
+    </head><body>
+      <strong class='subject'>Frog Wizards of Chana Tower</strong>
+    </body></html>
+    """
+    episodes_json = {
+        "result": {
+            "episodeList": [
+                {
+                    "episodeNo": 1,
+                    "thumbnail": "",
+                    "episodeTitle": "First",
+                    "viewerLink": "/en/canvas/frog-wizards-of-chana-tower/first/viewer?title_no=883187&episode_no=1",
+                    "exposureDateMillis": 0,
+                    "displayUp": True,
+                }
+            ],
+        }
+    }
+
+    fetcher = WebtoonFetcher(
+        client=DummyClient({
+            mobile_url: _make_response(mobile_url, text=main_html),
+            api_url: _make_response(api_url, json=episodes_json),
+        }),
+        series_url=url,
+    )
+
+    chapters = await fetcher.get_chapters_details(url)
+
+    assert [chapter.title for chapter in chapters] == ["First"]
+    assert chapters[0].viewer_url == (
+        "https://www.webtoons.com/en/canvas/frog-wizards-of-chana-tower/first/viewer?title_no=883187&episode_no=1"
+    )
+
+
+@pytest.mark.asyncio
+async def test_canvas_latest_uses_single_episode_list_request() -> None:
+    url = "https://www.webtoons.com/en/canvas/frog-wizards-of-chana-tower/list?title_no=883187"
+    mobile_url = "https://m.webtoons.com/en/canvas/frog-wizards-of-chana-tower/list?title_no=883187"
+    api_url = (
+        "https://m.webtoons.com/api/v1/canvas/883187/episodes"
+        f"?pageSize={REQUEST_ALL_EPISODES_PAGE_SIZE}&readingLanguageCode=en"
+    )
+    main_html = """
+    <html><head>
+      <link rel='canonical' href='https://www.webtoons.com/en/canvas/frog-wizards-of-chana-tower/list?title_no=883187' />
+    </head><body>
+      <strong class='subject'>Frog Wizards of Chana Tower</strong>
+    </body></html>
+    """
+    episodes_json = {
+        "result": {
+            "episodeList": [
+                {
+                    "episodeNo": 1,
+                    "thumbnail": "",
+                    "episodeTitle": "First",
+                    "viewerLink": "/en/canvas/frog-wizards-of-chana-tower/first/viewer?title_no=883187&episode_no=1",
+                    "exposureDateMillis": 0,
+                    "displayUp": True,
+                },
+                {
+                    "episodeNo": 2,
+                    "thumbnail": "",
+                    "episodeTitle": "Second",
+                    "viewerLink": "/en/canvas/frog-wizards-of-chana-tower/second/viewer?title_no=883187&episode_no=2",
+                    "exposureDateMillis": 0,
+                    "displayUp": True,
+                },
+            ],
+        }
+    }
+    fetcher = WebtoonFetcher(
+        client=DummyClient({
+            mobile_url: _make_response(mobile_url, text=main_html),
+            api_url: _make_response(api_url, json=episodes_json),
+        }),
+        series_url=url,
+    )
+
+    chapters = await fetcher.get_chapters_details(url, end_chapter=END_CHAPTER_LATEST)
+
+    assert [chapter.title for chapter in chapters] == ["Second"]
+    assert chapters[0].number == 2
+    assert chapters[0].total_chapters == 2
 
 
 @pytest.mark.asyncio
@@ -236,7 +342,10 @@ async def test_chapter_downloader_logs_warning_if_comicinfo_write_fails(caplog: 
 async def test_webtoon_downloader_cbz_includes_series_metadata(tmp_path: Path) -> None:
     url = "https://www.webtoons.com/en/fantasy/tower-of-god/list?title_no=95"
     mobile_url = "https://m.webtoons.com/en/fantasy/tower-of-god/list?title_no=95"
-    api_url = "https://m.webtoons.com/api/v1/webtoon/95/episodes?pageSize=99999"
+    api_url = (
+        "https://m.webtoons.com/api/v1/webtoon/95/episodes"
+        f"?pageSize={REQUEST_ALL_EPISODES_PAGE_SIZE}&readingLanguageCode=en"
+    )
     viewer_url = "https://www.webtoons.com/en/fantasy/tower-of-god/ep-1/viewer?title_no=95&episode_no=1"
 
     main_html = """

--- a/tests/test_webtoon_urls.py
+++ b/tests/test_webtoon_urls.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import httpx
+
+from webtoon_downloader.core.webtoon.api import (
+    REQUEST_ALL_EPISODES_PAGE_SIZE,
+    WEBTOON_TYPE_CANVAS,
+    WEBTOON_TYPE_ORIGINAL,
+    WebtoonSeriesType,
+    build_episodes_url,
+    build_series_api_url,
+)
+from webtoon_downloader.core.webtoon.client import WebtoonHttpClient
+from webtoon_downloader.core.webtoon.fetchers import WebtoonFetcher
+
+GLOBAL_WEBTOON_LANGUAGE_CODES = ("de", "en", "es", "fr", "id", "th", "zh-hant")
+ORIGINALS_GENRE_SEGMENTS = (
+    "action",
+    "comedy",
+    "drama",
+    "fantasy",
+    "horror",
+    "romance",
+    "super-hero",
+    "supernatural",
+    "thriller",
+)
+
+
+class DummyClient(WebtoonHttpClient):
+    async def get(self, url: str) -> httpx.Response:
+        raise AssertionError(url)
+
+
+def test_url_builder() -> None:
+    series_cases: tuple[tuple[WebtoonSeriesType, int, str], ...] = (
+        (WEBTOON_TYPE_ORIGINAL, 95, "https://m.webtoons.com/api/v1/webtoon/95"),
+        (WEBTOON_TYPE_CANVAS, 883187, "https://m.webtoons.com/api/v1/canvas/883187"),
+    )
+    for webtoon_type, series_id, expected_url in series_cases:
+        assert build_series_api_url(webtoon_type, series_id) == expected_url
+
+    for language_code in GLOBAL_WEBTOON_LANGUAGE_CODES:
+        url = build_episodes_url(
+            build_series_api_url(WEBTOON_TYPE_CANVAS, 883187),
+            page_size=REQUEST_ALL_EPISODES_PAGE_SIZE,
+            reading_language_code=language_code,
+        )
+        assert (
+            url == "https://m.webtoons.com/api/v1/canvas/883187/episodes"
+            f"?pageSize={REQUEST_ALL_EPISODES_PAGE_SIZE}&readingLanguageCode={language_code}"
+        )
+
+    assert (
+        build_episodes_url(
+            "https://m.webtoons.com/api/v1/canvas/883187/",
+            page_size=REQUEST_ALL_EPISODES_PAGE_SIZE,
+            reading_language_code="en",
+        )
+        == "https://m.webtoons.com/api/v1/canvas/883187/episodes"
+        f"?pageSize={REQUEST_ALL_EPISODES_PAGE_SIZE}&readingLanguageCode=en"
+    )
+    assert (
+        build_episodes_url(
+            "https://m.webtoons.com/api/v1/canvas/883187/episodes",
+            page_size=REQUEST_ALL_EPISODES_PAGE_SIZE,
+            reading_language_code="en",
+        )
+        == "https://m.webtoons.com/api/v1/canvas/883187/episodes"
+        f"?pageSize={REQUEST_ALL_EPISODES_PAGE_SIZE}&readingLanguageCode=en"
+    )
+    assert (
+        build_episodes_url(
+            build_series_api_url(WEBTOON_TYPE_ORIGINAL, 95),
+            page_size=REQUEST_ALL_EPISODES_PAGE_SIZE,
+        )
+        == f"https://m.webtoons.com/api/v1/webtoon/95/episodes?pageSize={REQUEST_ALL_EPISODES_PAGE_SIZE}"
+    )
+    assert (
+        build_episodes_url(
+            "https://m.webtoons.com/api/v1/canvas/883187/episodes?pageSize=1&readingLanguageCode=fr",
+            page_size=REQUEST_ALL_EPISODES_PAGE_SIZE,
+            reading_language_code="en",
+        )
+        == "https://m.webtoons.com/api/v1/canvas/883187/episodes"
+        f"?pageSize={REQUEST_ALL_EPISODES_PAGE_SIZE}&readingLanguageCode=en"
+    )
+
+
+def test_webtoon_url_parsing() -> None:
+    fetcher = WebtoonFetcher(client=DummyClient(), series_url="https://www.webtoons.com")
+
+    assert fetcher.get_series_api_url(
+        "https://www.webtoons.com/en/canvas/frog-wizards/list?title_no=883187", 883187
+    ) == build_series_api_url(WEBTOON_TYPE_CANVAS, 883187)
+    for genre_segment in ORIGINALS_GENRE_SEGMENTS:
+        url = f"https://www.webtoons.com/en/{genre_segment}/canvas-knight/list?title_no=95"
+        assert fetcher.get_series_api_url(url, 95) == build_series_api_url(WEBTOON_TYPE_ORIGINAL, 95)
+
+    for language_code in GLOBAL_WEBTOON_LANGUAGE_CODES:
+        url = f"https://www.webtoons.com/{language_code}/canvas/frog-wizards/list?title_no=883187"
+        assert fetcher.get_reading_language_code(url) == language_code

--- a/webtoon_downloader/core/webtoon/api.py
+++ b/webtoon_downloader/core/webtoon/api.py
@@ -1,18 +1,74 @@
 import logging
 from dataclasses import dataclass
-from typing import Literal
+from typing import Final, Literal, TypeAlias
 
 import dacite
+from furl import furl
 
-from webtoon_downloader.core.webtoon.client import WebtoonHttpClient
+from webtoon_downloader.core.webtoon.client import WebtoonHttpClient, WebtoonMobileURL
 
 log = logging.getLogger(__name__)
 
-WebtoonType = Literal["WEBTOON", "CANVAS"]
+DEFAULT_EPISODE_PAGE_SIZE: Final = 30
+"""Webtoon's default episode API page size."""
+
+REQUEST_ALL_EPISODES_PAGE_SIZE: Final = 99999
+"""Historical all-episodes page size used for one-call episode list requests."""
+
+WebtoonSeriesType: TypeAlias = Literal["webtoon", "canvas"]
+"""Known Webtoon episode API path segment values."""
+
+WebtoonLanguageCode: TypeAlias = Literal["de", "en", "es", "fr", "id", "th", "zh-hant"]
+"""Language path segments currently exposed by the global Webtoon site."""
+
+WEBTOON_TYPE_ORIGINAL: Final[Literal["webtoon"]] = "webtoon"
+"""Webtoon's API path segment for Originals series."""
+
+WEBTOON_TYPE_CANVAS: Final[Literal["canvas"]] = "canvas"
+"""Webtoon's API path segment for Canvas series."""
+
+WEBTOON_API_ROOT_PATH_SEGMENTS: Final = ("api", "v1")
+"""Root path segments for Webtoon's mobile API."""
+
+WEBTOON_LANGUAGE_CODES: Final[tuple[WebtoonLanguageCode, ...]] = ("de", "en", "es", "fr", "id", "th", "zh-hant")
+"""Language path segments currently exposed by the global Webtoon site."""
+
+EPISODES_PATH_SEGMENT: Final = "episodes"
+"""Webtoon's mobile API path segment for episode list requests."""
+
+
+def build_series_api_url(webtoon_type: WebtoonSeriesType, series_id: int) -> str:
+    """Build a Webtoon mobile series API URL."""
+    url = furl(WebtoonMobileURL)
+    url.path.segments = [*WEBTOON_API_ROOT_PATH_SEGMENTS, webtoon_type, str(series_id)]
+    return str(url.url)
+
+
+def build_episodes_url(
+    series_api_url: str,
+    *,
+    page_size: int,
+    reading_language_code: WebtoonLanguageCode | None = None,
+) -> str:
+    """Build a Webtoon mobile episode-list API URL."""
+    url = furl(series_api_url)
+    path_segments = [segment for segment in url.path.segments if segment]
+    if not path_segments or path_segments[-1] != EPISODES_PATH_SEGMENT:
+        path_segments.append(EPISODES_PATH_SEGMENT)
+
+    url.path.segments = path_segments
+    url.args.clear()
+    url.args["pageSize"] = page_size
+    if reading_language_code:
+        url.args["readingLanguageCode"] = reading_language_code
+
+    return str(url.url)
 
 
 @dataclass
 class EpisodeInfo:
+    """Episode item returned by Webtoon's mobile episode API."""
+
     episodeNo: int
     thumbnail: str
     episodeTitle: str
@@ -24,29 +80,40 @@ class EpisodeInfo:
 
 @dataclass
 class GetEpisodesResponseResult:
+    """Payload wrapper containing the episode list returned by Webtoon."""
+
     episodeList: list[EpisodeInfo]
 
 
 @dataclass
 class GetEpisodesResponse:
+    """Top-level response shape returned by Webtoon's episode API."""
+
     result: GetEpisodesResponseResult
 
 
 @dataclass
 class WebtoonAPI:
+    """Small client for Webtoon's mobile API endpoints."""
+
     client: WebtoonHttpClient
 
-    async def get_episodes_data(self, series_api_url: str, page_size: int = 30, cursor: int = 0) -> list[EpisodeInfo]:
-        """Returns a list of episode data for a given series ID."""
-        # Examples for both webtoon and canvas
-        ## https://m.webtoons.com/api/v1/canvas/877457/episodes?pageSize=30
-        ## https://m.webtoons.com/api/v1/webtoon/95/episodes?pageSize=30
-
-        url = f"{series_api_url}/episodes?pageSize={page_size}"
-        if cursor > 0:
-            url = f"{url}&cursor={cursor}"
-
-        resp = dacite.from_dict(data_class=GetEpisodesResponse, data=(await self.client.get(url)).json())
+    async def get_episodes_data(
+        self,
+        series_api_url: str,
+        page_size: int = DEFAULT_EPISODE_PAGE_SIZE,
+        reading_language_code: WebtoonLanguageCode | None = None,
+    ) -> list[EpisodeInfo]:
+        """Return episode data for a given series ID."""
+        # Canvas series return an HTTP 500 error when readingLanguageCode is not provided.
+        url = build_episodes_url(
+            series_api_url,
+            page_size=page_size,
+            reading_language_code=reading_language_code,
+        )
+        response = await self.client.get(url)
+        response.raise_for_status()
+        resp = dacite.from_dict(data_class=GetEpisodesResponse, data=response.json())
         data = resp.result.episodeList
         log.debug("Received %d episodes", len(data))
         return data

--- a/webtoon_downloader/core/webtoon/downloaders/comic.py
+++ b/webtoon_downloader/core/webtoon/downloaders/comic.py
@@ -6,7 +6,6 @@ import re
 from dataclasses import dataclass, field
 from os import PathLike
 from pathlib import Path
-from typing import Literal
 
 from furl import furl
 
@@ -21,7 +20,7 @@ from webtoon_downloader.core.webtoon.downloaders.options import StorageType, Web
 from webtoon_downloader.core.webtoon.downloaders.result import DownloadResult
 from webtoon_downloader.core.webtoon.exporter import DataExporter
 from webtoon_downloader.core.webtoon.extractor import ElementNotFoundError, WebtoonMainPageExtractor
-from webtoon_downloader.core.webtoon.fetchers import WebtoonFetcher
+from webtoon_downloader.core.webtoon.fetchers import END_CHAPTER_LATEST, EndChapter, WebtoonFetcher
 from webtoon_downloader.core.webtoon.models import ChapterInfo
 from webtoon_downloader.core.webtoon.namer import NonSeparateFileNameGenerator, SeparateFileNameGenerator
 from webtoon_downloader.storage import AioFolderWriter, AioPdfWriter, AioWriter, AioZipWriter
@@ -57,7 +56,7 @@ class WebtoonDownloader:
     quality: int
 
     start_chapter: int | None = None
-    end_chapter: int | None | Literal["latest"] = None
+    end_chapter: EndChapter = None
     directory: str | PathLike[str] | None = None
     exporter: DataExporter | None = None
     on_webtoon_fetched: OnWebtoonFetchCallback | None = None
@@ -265,9 +264,9 @@ async def download_webtoon(opts: WebtoonDownloadOptions) -> list[DownloadResult]
         concurrent_downloads_limit=opts.concurrent_chapters,
     )
 
-    end: int | None | Literal["latest"]
+    end: EndChapter
     if opts.latest:
-        start, end = None, "latest"
+        start, end = None, END_CHAPTER_LATEST
     else:
         start, end = opts.start, opts.end
 

--- a/webtoon_downloader/core/webtoon/fetchers.py
+++ b/webtoon_downloader/core/webtoon/fetchers.py
@@ -3,24 +3,36 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from enum import Enum
-from typing import Literal
+from typing import Final, Literal, TypeAlias, cast
 
 from bs4 import BeautifulSoup, Tag
 from furl import furl
 
 from webtoon_downloader.core.exceptions import (
-    ChapterDataEpisodeNumberFetchError,
-    ChapterTitleFetchError,
-    ChapterURLFetchError,
     InvalidURL,
     SeriesTitleFetchError,
     WebtoonGetError,
 )
-from webtoon_downloader.core.webtoon.api import WebtoonAPI
+from webtoon_downloader.core.webtoon.api import (
+    REQUEST_ALL_EPISODES_PAGE_SIZE,
+    WEBTOON_LANGUAGE_CODES,
+    WEBTOON_TYPE_CANVAS,
+    WEBTOON_TYPE_ORIGINAL,
+    WebtoonAPI,
+    WebtoonLanguageCode,
+    WebtoonSeriesType,
+    build_series_api_url,
+)
 from webtoon_downloader.core.webtoon.client import WebtoonHttpClient, WebtoonURL
 from webtoon_downloader.core.webtoon.models import ChapterInfo
 
 log = logging.getLogger(__name__)
+
+END_CHAPTER_LATEST: Final = "latest"
+"""Sentinel used internally when the caller requests only the latest episode."""
+
+EndChapter: TypeAlias = int | None | Literal["latest"]
+"""Chapter range end value accepted by downloader/fetcher APIs."""
 
 
 class WebtoonDomain(str, Enum):
@@ -81,34 +93,6 @@ class WebtoonFetcher:
 
         return int(title)
 
-    def _get_viewer_url(self, tag: Tag) -> str:
-        """Returns the viewer URL from the scrapped tag object"""
-        viewer_url_tag = tag.find("a")
-        if not isinstance(viewer_url_tag, Tag):
-            raise ChapterURLFetchError
-
-        return self._convert_url_domain(str(viewer_url_tag["href"]), target_subdomain=WebtoonDomain.STANDARD)
-
-    def _get_chapter_title(self, tag: Tag) -> str:
-        """Returns the chapter title from the scrapped tag object"""
-        chapter_details_tag = tag.find("p", class_="sub_title")
-        if not isinstance(chapter_details_tag, Tag):
-            raise ChapterTitleFetchError
-
-        chapter_details_tag = chapter_details_tag.find("span", class_="ellipsis")
-        if not isinstance(chapter_details_tag, Tag):
-            raise ChapterTitleFetchError
-
-        return chapter_details_tag.text
-
-    def _get_data_episode_num(self, tag: Tag) -> int:
-        """Returns the chapter data episode number from the scrapped tag object"""
-        data_episode_no_tag = tag["data-episode-no"]
-        if not isinstance(data_episode_no_tag, str):
-            raise ChapterDataEpisodeNumberFetchError
-
-        return int(data_episode_no_tag)
-
     def _get_series_title(self, soup: BeautifulSoup) -> str:
         """Returns the series title from the scrapped tag object"""
         # Look for the new format used in the provided HTML.
@@ -122,16 +106,30 @@ class WebtoonFetcher:
 
         return series_title_tag.text
 
-    def _get_webtoon_type(self, series_url: str) -> Literal["webtoon", "canvas"]:
-        if "canvas" in series_url:
-            return "canvas"
-        return "webtoon"
+    def _get_webtoon_type(self, series_url: str) -> WebtoonSeriesType:
+        path_segments = [segment for segment in furl(series_url).path.segments if segment]
+        return WEBTOON_TYPE_CANVAS if WEBTOON_TYPE_CANVAS in path_segments else WEBTOON_TYPE_ORIGINAL
+
+    def get_series_api_url(self, series_url: str, series_id: int) -> str:
+        """Return the mobile API URL for a Webtoon series."""
+        return build_series_api_url(self._get_webtoon_type(series_url), series_id)
 
     def _get_series_api_url(self, series_url: str, series_id: int) -> str:
-        return f"https://m.webtoons.com/api/v1/{self._get_webtoon_type(series_url)}/{series_id}"
+        return self.get_series_api_url(series_url, series_id)
+
+    def _get_reading_language_code(self, series_url: str) -> WebtoonLanguageCode | None:
+        """Return the URL language segment Webtoon's episode API expects."""
+        path_segments = [segment for segment in furl(series_url).path.segments if segment]
+        if path_segments and path_segments[0] in WEBTOON_LANGUAGE_CODES:
+            return cast("WebtoonLanguageCode", path_segments[0])
+        return None
+
+    def get_reading_language_code(self, series_url: str) -> WebtoonLanguageCode | None:
+        """Return the language segment from a Webtoon URL."""
+        return self._get_reading_language_code(series_url)
 
     async def get_chapters_details(
-        self, series_url: str, start_chapter: int | None = None, end_chapter: int | None | Literal["latest"] = None
+        self, series_url: str, start_chapter: int | None = None, end_chapter: EndChapter = None
     ) -> list[ChapterInfo]:
         """
         fetches and parses chapter details from a given Webtoon series URL.
@@ -159,8 +157,11 @@ class WebtoonFetcher:
         title_id = self._get_title_no(soup)
         log.debug("Title ID: %s", title_id)
         series_title = self._get_series_title(soup)
+
         chapter_items = await webtoon_api.get_episodes_data(
-            (self._get_series_api_url(mobile_url, title_id)), page_size=99999
+            (self._get_series_api_url(mobile_url, title_id)),
+            page_size=REQUEST_ALL_EPISODES_PAGE_SIZE,
+            reading_language_code=self._get_reading_language_code(mobile_url),
         )
 
         chapter_details: list[ChapterInfo] = []
@@ -175,7 +176,7 @@ class WebtoonFetcher:
             )
             chapter_details.append(chapter_info)
 
-        if end_chapter == "latest":
+        if end_chapter == END_CHAPTER_LATEST:
             return [chapter_details[-1]]
 
         return chapter_details[int(start_chapter or 1) - 1 : end_chapter]

--- a/webtoon_downloader/storage/pdf.py
+++ b/webtoon_downloader/storage/pdf.py
@@ -59,13 +59,8 @@ class AioPdfWriter:
 
     @stream_error_handler
     async def __aenter__(self) -> AioPdfWriter:
-        container = self.container
-        if isinstance(container, str):
-            Path(container).parent.mkdir(parents=True, exist_ok=True)
-        elif isinstance(container, PathLike):
-            fspath = container.__fspath__()
-            if isinstance(fspath, str):
-                Path(fspath).parent.mkdir(parents=True, exist_ok=True)
+        if isinstance(self.container, str | PathLike):
+            Path(self.container).parent.mkdir(parents=True, exist_ok=True)
         self._pages_data = []
         self._doc = fitz.open()
         return self

--- a/webtoon_downloader/storage/zip.py
+++ b/webtoon_downloader/storage/zip.py
@@ -33,7 +33,7 @@ def _open_zip_file(container: ZipContainer, mode: ZipWriteMode) -> zipfile.ZipFi
     """Returns a ZipFile object from the provided container type and file open mode"""
     if isinstance(container, io.BytesIO):
         return zipfile.ZipFile(container, mode=mode, compression=zipfile.ZIP_DEFLATED)
-    elif isinstance(container, (str, Path)):
+    elif isinstance(container, str | PathLike):
         container_path = Path(container)
         container_path.parent.mkdir(parents=True, exist_ok=True)
         return zipfile.ZipFile(container_path, mode=mode, compression=zipfile.ZIP_DEFLATED)
@@ -75,16 +75,15 @@ class AioZipWriter:
         Returns:
             The number of bytes written.
         """
-        data = b""
+        data = bytearray()
         written = 0
 
         async for chunk in stream:
-            data += chunk
+            data.extend(chunk)
             written += len(chunk)
 
         async with self._lock:
-            loop = asyncio.get_running_loop()
-            await loop.run_in_executor(None, self._zip_file.writestr, item_name, data)
+            self._zip_file.writestr(item_name, bytes(data))
 
         return written
 
@@ -114,7 +113,7 @@ class AioFileBufferedZipWriter(AioZipWriter):
 
     _lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     _zip_file: zipfile.ZipFile = field(init=False)
-    _temp_files: list[Path] = field(default_factory=list)
+    _temp_files: set[Path] = field(default_factory=set)
 
     @stream_error_handler
     async def __aenter__(self) -> AioFileBufferedZipWriter:
@@ -136,7 +135,7 @@ class AioFileBufferedZipWriter(AioZipWriter):
         written = 0
         with tempfile.NamedTemporaryFile(delete=False, suffix=".webtoon_downloader.tmp") as tmp:
             temp_file = Path(tmp.name)
-            self._temp_files.append(temp_file)
+            self._temp_files.add(temp_file)
 
         try:
             async with aiofiles.open(temp_file, mode="wb") as file:
@@ -146,6 +145,7 @@ class AioFileBufferedZipWriter(AioZipWriter):
             await self._add_to_zip(temp_file, item_name)
         finally:
             temp_file.unlink(missing_ok=True)
+            self._temp_files.discard(temp_file)
 
         return written
 
@@ -162,8 +162,7 @@ class AioFileBufferedZipWriter(AioZipWriter):
                 temp_file_path.unlink()
 
         async with self._lock:
-            loop = asyncio.get_running_loop()
-            await loop.run_in_executor(None, _write_to_zip)
+            _write_to_zip()
 
     @stream_error_handler
     async def __aexit__(


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation is updated

**Description of changes**

Closes #123

- Fixes Canvas episode API requests by sending `readingLanguageCode` from the Webtoon URL language segment.
- Keeps episode list fetching to one API request using the existing all-episodes page size; no cursor pagination or HTML fallback is added.
- Adds reusable Webtoon API URL builders for series and episode endpoints.
- Adds typed Webtoon API path and language constants, covering global language paths found on Webtoon: `de`, `en`, `es`, `fr`, `id`, `th`, `zh-hant`.
- Adds URL parsing/builder coverage plus Canvas regression tests for normal and `--latest` chapter fetching.
- Removes unused old HTML chapter-list parser helpers from the fetcher.
- Updates ZIP writing to avoid the executor shutdown hang while keeping the existing async writer API.